### PR TITLE
Fix Feature Viewer Slider Position

### DIFF
--- a/pygenefinder/gui.py
+++ b/pygenefinder/gui.py
@@ -494,6 +494,7 @@ class pygenefinderApp(QMainWindow):
         s.load_records(recs)
         s.set_record(recname=data['id'])
         s.redraw(start = data.start-2000, end=data.end+2000)
+        s.slider.setValue(data.start + ((data.end-data.start)/2))
         s.show()
         return
 


### PR DESCRIPTION
As per the issue I posted earlier, I have submitted a pull request. The position of the slider in the feature viewer when selecting "view features" in the gui is now updated to the current location instead of the start of the genome.